### PR TITLE
Issue #36405 Fix

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Customer/Model/Address/CreateAddressTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Model/Address/CreateAddressTest.php
@@ -493,7 +493,7 @@ class CreateAddressTest extends TestCase
                     'request_date' => '',
                     'request_identifier' => '123123123',
                     'request_success' => $isRequestSuccess,
-                    'request_message' => __(''),
+                    'request_message' => '',
                 ],
             ]
         );


### PR DESCRIPTION
### Preconditions and environment

- Magento version: 2.4.2 p1
- While trying to generate languages files i stumbled across this issue which prevented me from being able complete the task. 

### Steps to reproduce

1. From the CLI 
2. enter `bin/magento i18n:collect-phrases --o="/full/path/to/magento/app/design/frontend/custom/theme/i18n/en_US.csv" --magento ` and hit return

### Expected result

Collection and generation of translatable words in `en_US.csv` generated to directory `/full/path/to/magento/app/design/frontend/custom/theme/i18n/`

### Actual result

In Phrase.php line 90: Missed phrase  
                 

### Additional information

_No response_

### Release note

_No response_

### Triage and priority

- [ ] Severity: **S0** _- Affects critical data or functionality and leaves users without workaround._
- [ ] Severity: **S1** _- Affects critical data or functionality and forces users to employ a workaround._
- [X] Severity: **S2** _- Affects non-critical data or functionality and forces users to employ a workaround._
- [ ] Severity: **S3** _- Affects non-critical data or functionality and does not force users to employ a workaround._
- [ ] Severity: **S4** _- Affects aesthetics, professional look and feel, “quality” or “usability”._